### PR TITLE
Fix #6 implement feature cross support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Once calculated you can print the data, look at the R^2, Variance, residuals, et
 ```go
 // Get the coefficient for the "Inhabitants" variable 0:
 c := r.Coeff(0)
-``` 
+```
 
 You can also use the model to predict new data points
 
@@ -78,4 +78,15 @@ You can also use the model to predict new data points
 prediction, err := r.Predict([]float64{587000, 16.5, 6.2})
 ```
 
+Feature crosses are supported so your model can capture fixed non-linear relationships
 
+```go
+
+r.Train(
+  regression.DataPoint(11.2, []float64{587000, 16.5, 6.2}),
+)
+//Add a new feature which is the first variable (index 0) to the power of 2
+r.AddCross(PowCross(0, 2))
+r.Run()
+
+```

--- a/crosses.go
+++ b/crosses.go
@@ -29,16 +29,37 @@ func (c *functionalCross) ExtendNames(input map[int]string, initialSize int) int
 	return len(c.boundVars)
 }
 
+// Feature cross based on computing the power of an input.
 func PowCross(i int, power float64) featureCross {
 	return &functionalCross{
 		functionName: "^" + strconv.FormatFloat(power, 'f', -1, 64),
 		boundVars:    []int{i},
 		crossFn: func(vars []float64) []float64 {
-			if i >= len(vars) {
-				panic("Cross specified out of bounds")
-			}
 
 			return []float64{math.Pow(vars[i], power)}
+		},
+	}
+}
+
+// Feature cross based on the multiplication of multiple inputs.
+func MultiplierCross(vars ...int) featureCross {
+	name := ""
+	for i, v := range vars {
+		name += strconv.Itoa(v)
+		if i < (len(vars) - 1) {
+			name += "*"
+		}
+	}
+
+	return &functionalCross{
+		functionName: name,
+		boundVars:    vars,
+		crossFn: func(input []float64) []float64 {
+			var output float64 = 1
+			for _, variableIndex := range vars {
+				output *= input[variableIndex]
+			}
+			return []float64{output}
 		},
 	}
 }

--- a/crosses.go
+++ b/crosses.go
@@ -1,0 +1,44 @@
+package regression
+
+import (
+	"math"
+	"strconv"
+)
+
+type featureCross interface {
+	Calculate([]float64) []float64 //must return the same number of features each run
+	ExtendNames(map[int]string, int) int
+}
+
+type functionalCross struct {
+	functionName string
+	boundVars    []int
+	crossFn      func([]float64) []float64
+}
+
+func (c *functionalCross) Calculate(input []float64) []float64 {
+	return c.crossFn(input)
+}
+
+func (c *functionalCross) ExtendNames(input map[int]string, initialSize int) int {
+	for i, varIndex := range c.boundVars {
+		if input[varIndex] != "" {
+			input[initialSize+i] = "(" + input[varIndex] + ")" + c.functionName
+		}
+	}
+	return len(c.boundVars)
+}
+
+func PowCross(i int, power float64) featureCross {
+	return &functionalCross{
+		functionName: "^" + strconv.FormatFloat(power, 'f', -1, 64),
+		boundVars:    []int{i},
+		crossFn: func(vars []float64) []float64 {
+			if i >= len(vars) {
+				panic("Cross specified out of bounds")
+			}
+
+			return []float64{math.Pow(vars[i], power)}
+		},
+	}
+}

--- a/crosses_test.go
+++ b/crosses_test.go
@@ -1,0 +1,33 @@
+package regression
+
+import (
+	"testing"
+)
+
+func TestPowCrosses(t *testing.T) {
+	cross1 := PowCross(0, 2) //cross of the variable at index 0
+	if cross1.Calculate([]float64{2})[0] != 4 {
+		t.Error("Incorrect value")
+	}
+
+	cross2 := PowCross(1, 2) //cross of the variable at index 1
+	if cross2.Calculate([]float64{2, -3})[0] != 9 {
+		t.Error("Incorrect value, got", cross2.Calculate([]float64{2, -3}))
+	}
+}
+
+func TestFunctionalCrossExtendNames(t *testing.T) {
+	varNames := map[int]string{1: "Number of cars", 0: "fgsd"}
+	cross := PowCross(1, 2) //cross of the variable at index 0
+	newVars := cross.ExtendNames(varNames, len(varNames))
+
+	if len(varNames) != 3 {
+		t.Error("Expected another name")
+	}
+	if varNames[2] != "(Number of cars)^2" {
+		t.Error("Expected '(Number of cars)^2'")
+	}
+	if newVars != 1 {
+		t.Error("Expected 1 new var")
+	}
+}

--- a/crosses_test.go
+++ b/crosses_test.go
@@ -16,6 +16,18 @@ func TestPowCrosses(t *testing.T) {
 	}
 }
 
+func TestMultiplicationCrosses(t *testing.T) {
+	cross1 := MultiplierCross(0, 1, 3)
+	if cross1.Calculate([]float64{2, 3, 4, 5})[0] != 30 {
+		t.Errorf("Incorrect value, expected 30 got %.2f", cross1.Calculate([]float64{2, 3, 4, 5})[0])
+	}
+
+	cross2 := MultiplierCross(0, 1)
+	if cross2.Calculate([]float64{2, 3})[0] != 6 {
+		t.Errorf("Incorrect value, expected 6 got %.2f", cross1.Calculate([]float64{2, 3, 4, 5})[0])
+	}
+}
+
 func TestFunctionalCrossExtendNames(t *testing.T) {
 	varNames := map[int]string{1: "Number of cars", 0: "fgsd"}
 	cross := PowCross(1, 2) //cross of the variable at index 0

--- a/regression.go
+++ b/regression.go
@@ -51,6 +51,12 @@ func (r *Regression) Predict(vars []float64) (float64, error) {
 	if !r.initialised {
 		return 0, errNotEnoughData
 	}
+
+	// apply any features crosses to vars
+	for _, cross := range r.crosses {
+		vars = append(vars, cross.Calculate(vars)...)
+	}
+
 	p := r.Coeff(0)
 	for j := 1; j < len(r.data[0].Variables)+1; j++ {
 		p += r.Coeff(j) * vars[j-1]
@@ -101,6 +107,7 @@ func (r *Regression) Train(d ...*dataPoint) {
 
 // Apply any feature crosses, generating new observations and updating the data points, as well as
 // populating variable names for the feature crosses.
+// this should only be run once, as part of Run().
 func (r *Regression) applyCrosses() {
 	unusedVariableIndexCursor := len(r.data[0].Variables)
 	for _, point := range r.data {

--- a/regression_test.go
+++ b/regression_test.go
@@ -54,3 +54,40 @@ func TestRun(t *testing.T) {
 		t.Errorf("R^2 was %.2f, but we expected > 80", r.R2)
 	}
 }
+
+func TestCrossApply(t *testing.T) {
+	r := new(Regression)
+	r.SetObserved("Input-Squared plus Input")
+	r.SetVar(0, "Input")
+	r.Train(
+		DataPoint(6, []float64{2}),
+		DataPoint(20, []float64{4}),
+		DataPoint(30, []float64{5}),
+	)
+	r.AddCross(PowCross(0, 2))
+	err := r.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Printf("Regression formula:\n%v\n", r.Formula)
+	fmt.Printf("Regression:\n%s\n", r)
+	if r.names.vars[1] != "(Input)^2" {
+		t.Error("Name incorrect")
+	}
+
+	for i, c := range r.coeff {
+		if i == 0 {
+			// This is the offset and not a coeff
+			continue
+		}
+		if c < 0 {
+			t.Errorf("Coefficient is negative, but shouldn't be: %.2f", c)
+		}
+	}
+
+	//  We know this set has an R^2 above 80
+	if r.R2 < 0.8 {
+		t.Errorf("R^2 was %.2f, but we expected > 80", r.R2)
+	}
+}

--- a/regression_test.go
+++ b/regression_test.go
@@ -63,8 +63,11 @@ func TestCrossApply(t *testing.T) {
 		DataPoint(6, []float64{2}),
 		DataPoint(20, []float64{4}),
 		DataPoint(30, []float64{5}),
+		DataPoint(72, []float64{8}),
+		DataPoint(156, []float64{12}),
 	)
 	r.AddCross(PowCross(0, 2))
+	r.AddCross(PowCross(0, 7))
 	err := r.Run()
 	if err != nil {
 		t.Error(err)
@@ -89,5 +92,14 @@ func TestCrossApply(t *testing.T) {
 	//  We know this set has an R^2 above 80
 	if r.R2 < 0.8 {
 		t.Errorf("R^2 was %.2f, but we expected > 80", r.R2)
+	}
+
+	// Test that predict uses the cross as well
+	val, err := r.Predict([]float64{6})
+	if err != nil {
+		t.Error(err)
+	}
+	if val <= 41.999 && val >= 42.001 {
+		t.Errorf("Expected 42, got %.2f", val)
 	}
 }


### PR DESCRIPTION
I didnt wrap DataPoint() because that limits usefulness. Instead, you provide a featureCross object that calculates the new features + gives you new variable names.

Implementing more crosses in the future should be incredibly simple. I've only bothered with power-of crosses for now.