### PR TITLE
Added MakeDataPoints

### DIFF
--- a/regression.go
+++ b/regression.go
@@ -278,3 +278,31 @@ func (r *Regression) String() string {
 	str += fmt.Sprintf("\nR2 = %v\n", r.R2)
 	return str
 }
+
+func MakeDataPoints(a [][]float64, obsIndex int) []*dataPoint {
+	if obsIndex != 0 {
+		return perverseMakeDataPoints(a, obsIndex)
+	}
+
+	retVal := make([]*dataPoint, 0, len(a))
+	for _, r := range a {
+		retVal = append(retVal, DataPoint(r[0], r[1:]))
+	}
+	return retVal
+}
+
+func perverseMakeDataPoints(a [][]float64, obsIndex int) []*dataPoint {
+	retVal := make([]*dataPoint, 0, len(a))
+	for _, r := range a {
+		obs := r[obsIndex]
+		others := make([]float64, 0, len(r)-1)
+		for i, c := range r {
+			if i == obsIndex {
+				continue
+			}
+			others = append(others, c)
+		}
+		retVal = append(retVal, DataPoint(obs, others))
+	}
+	return retVal
+}

--- a/regression.go
+++ b/regression.go
@@ -279,14 +279,27 @@ func (r *Regression) String() string {
 	return str
 }
 
+// MakeDataPoints makes a `[]*dataPoint` from a `[][]float64`. The expected fomat for the input is a row-major [][]float64.
+// That is to say the first slice represents a row, and the second represents the cols.
+// Furthermore it is expected that all the col slices are of the same length.
+// The obsIndex parameter indicates which column should be used
 func MakeDataPoints(a [][]float64, obsIndex int) []*dataPoint {
-	if obsIndex != 0 {
+	if obsIndex != 0 && obsIndex != len(a[0])-1 {
 		return perverseMakeDataPoints(a, obsIndex)
 	}
 
 	retVal := make([]*dataPoint, 0, len(a))
+	if obsIndex == 0 {
+		for _, r := range a {
+			retVal = append(retVal, DataPoint(r[0], r[1:]))
+		}
+		return retVal
+	}
+
+	// otherwise the observation is expected to be the last col
+	last := len(a[0]) - 1
 	for _, r := range a {
-		retVal = append(retVal, DataPoint(r[0], r[1:]))
+		retVal = append(retVal, DataPoint(r[last], r[:last]))
 	}
 	return retVal
 }

--- a/regression_test.go
+++ b/regression_test.go
@@ -103,3 +103,43 @@ func TestCrossApply(t *testing.T) {
 		t.Errorf("Expected 42, got %.2f", val)
 	}
 }
+
+func TestMakeDataPoints(t *testing.T) {
+	a := [][]float64{
+		{1, 2, 3, 4},
+		{2, 2, 3, 4},
+		{3, 2, 3, 4},
+	}
+	correct := []float64{2, 3, 4}
+
+	dps := MakeDataPoints(a, 0)
+	for i, dp := range dps {
+		for i, v := range dp.Variables {
+			if correct[i] != v {
+				t.Errorf("Expected variables to be %v. Got %v instead", correct, dp.Variables)
+			}
+		}
+		if dp.Observed != float64(i+1) {
+			t.Error("Expected observed to be the same as the index")
+		}
+	}
+
+	a = [][]float64{
+		{1, 2, 3, 4},
+		{1, 2, 3, 4},
+		{1, 2, 3, 4},
+	}
+	correct = []float64{1, 3, 4}
+	dps = MakeDataPoints(a, 1)
+	for _, dp := range dps {
+		for i, v := range dp.Variables {
+			if correct[i] != v {
+				t.Errorf("Expected variables to be %v. Got %v instead", correct, dp.Variables)
+			}
+		}
+		if dp.Observed != 2.0 {
+			t.Error("Expected observed to be the same as the index")
+		}
+	}
+
+}

--- a/regression_test.go
+++ b/regression_test.go
@@ -142,4 +142,17 @@ func TestMakeDataPoints(t *testing.T) {
 		}
 	}
 
+	correct = []float64{1, 2, 3}
+	dps = MakeDataPoints(a, 3)
+	for _, dp := range dps {
+		for i, v := range dp.Variables {
+			if correct[i] != v {
+				t.Errorf("Expected variables to be %v. Got %v instead", correct, dp.Variables)
+			}
+		}
+		if dp.Observed != 4.0 {
+			t.Error("Expected observed to be the same as the index")
+		}
+	}
+
 }


### PR DESCRIPTION
The `dataPoint` data structure is not exported. In use cases where there is a need to do dynamic regressions,  access to create a `[]*dataPoint` would be important, given that the number of rows won't necessarily be known ahead of time. 

The decision to allow `[][]float64` instead of something more esoteric (for example the signature could be: `func MakeDataPoints(obs []float64, cols [][]float64) []*dataPoint`) is because in most regression analyses, the data would already be nicely structured in a matrix where the first col is the observation. 

The reason for not choosing `*mat.Dense` as an input is simply because `[][]float64` has the most wide interoperability with any other Go programs. 