### PR TITLE
Added a new DataPoints type

### DIFF
--- a/regression.go
+++ b/regression.go
@@ -41,6 +41,10 @@ type describe struct {
 	vars map[int]string
 }
 
+// DataPoints is a slice of *dataPoint .
+// This type allows for easier constuction of training data points
+type DataPoints []*dataPoint
+
 // Creates a new dataPoint
 func DataPoint(obs float64, vars []float64) *dataPoint {
 	return &dataPoint{Observed: obs, Variables: vars}


### PR DESCRIPTION
This solves the issue of having to export `*dataPoint`.

This is the same main function from the README, but using `DataPoints`

```
package main

import (
	"fmt"

	"github.com/sajari/regression"
)

func main() {
	r := new(regression.Regression)
	r.SetObserved("Murders per annum per 1,000,000 inhabitants")
	r.SetVar(0, "Inhabitants")
	r.SetVar(1, "Percent with incomes below $5000")
	r.SetVar(2, "Percent unemployed")

	dp := make(regression.DataPoints, 0, 10)
	dp = append(dp, regression.DataPoint(11.2, []float64{587000, 16.5, 6.2}))
	dp = append(dp, regression.DataPoint(13.4, []float64{643000, 20.5, 6.4}))
	dp = append(dp, regression.DataPoint(40.7, []float64{635000, 26.3, 9.3}))
	dp = append(dp, regression.DataPoint(5.3, []float64{692000, 16.5, 5.3}))
	dp = append(dp, regression.DataPoint(24.8, []float64{1248000, 19.2, 7.3}))
	dp = append(dp, regression.DataPoint(12.7, []float64{643000, 16.5, 5.9}))
	dp = append(dp, regression.DataPoint(20.9, []float64{1964000, 20.2, 6.4}))
	dp = append(dp, regression.DataPoint(35.7, []float64{1531000, 21.3, 7.6}))
	dp = append(dp, regression.DataPoint(8.7, []float64{713000, 17.2, 4.9}))
	dp = append(dp, regression.DataPoint(9.6, []float64{749000, 14.3, 6.4}))
	dp = append(dp, regression.DataPoint(14.5, []float64{7895000, 18.1, 6}))
	dp = append(dp, regression.DataPoint(26.9, []float64{762000, 23.1, 7.4}))
	dp = append(dp, regression.DataPoint(15.7, []float64{2793000, 19.1, 5.8}))
	dp = append(dp, regression.DataPoint(36.2, []float64{741000, 24.7, 8.6}))
	dp = append(dp, regression.DataPoint(18.1, []float64{625000, 18.6, 6.5}))
	dp = append(dp, regression.DataPoint(28.9, []float64{854000, 24.9, 8.3}))
	dp = append(dp, regression.DataPoint(14.9, []float64{716000, 17.9, 6.7}))
	dp = append(dp, regression.DataPoint(25.8, []float64{921000, 22.4, 8.6}))
	dp = append(dp, regression.DataPoint(21.7, []float64{595000, 20.2, 8.4}))
	dp = append(dp, regression.DataPoint(25.7, []float64{3353000, 16.9, 6.7}))

	r.Train(dp...)
	r.Run()

	fmt.Printf("Regression formula:\n%v\n", r.Formula)
	fmt.Printf("Regression:\n%s\n", r)
}
```