### PR TITLE
Regression: Cleaning up the package with Go comments and exported Errors

### DIFF
--- a/regression.go
+++ b/regression.go
@@ -196,9 +196,9 @@ func (r *Regression) Run() error {
 	for i, val := range c {
 		r.coeff[i] = val
 		if i == 0 {
-			r.Formula = fmt.Sprintf("Predicted = %.2f", val)
+			r.Formula = fmt.Sprintf("Predicted = %.4f", val)
 		} else {
-			r.Formula += fmt.Sprintf(" + %v*%.2f", r.GetVar(i-1), val)
+			r.Formula += fmt.Sprintf(" + %v*%.4f", r.GetVar(i-1), val)
 		}
 	}
 


### PR DESCRIPTION
This PR cleans up the comments to follow Go's expected format.  Errors have also become exportable things so that they can be checked against explicitly by the calling code.